### PR TITLE
Allow building with GHC 9.10

### DIFF
--- a/named-text.cabal
+++ b/named-text.cabal
@@ -58,7 +58,7 @@ library
     import:           bldspec
     hs-source-dirs:   .
     default-language: Haskell2010
-    build-depends:    base >= 4.13 && < 4.20
+    build-depends:    base >= 4.13 && < 4.21
                     , deepseq
                     , hashable
                     , prettyprinter >= 1.7.0 && < 1.8
@@ -67,7 +67,7 @@ library
     exposed-modules:  Data.Name
     other-modules:    Data.Name.Internal
     if flag(with-json)
-      build-depends: aeson >= 1.5 && < 2.2
+      build-depends: aeson >= 1.5 && < 2.3
       exposed-modules: Data.Name.JSON
 
 
@@ -83,12 +83,12 @@ test-suite namedTests
                     , parameterized-utils >= 2.1 && < 2.2
                     , prettyprinter
                     , sayable
-                    , tasty >= 1.4 && < 1.5
+                    , tasty >= 1.4 && < 1.6
                     , tasty-ant-xml >= 1.1 && < 1.2
                     , tasty-checklist >= 1.0 && < 1.1
                     , tasty-hspec >= 1.2 && < 1.3
                     , text
                     , unordered-containers
     if flag(with-json)
-      build-depends: aeson >= 1.5 && < 2.2
+      build-depends: aeson >= 1.5 && < 2.3
                    , bytestring


### PR DESCRIPTION
This bumps the upper version bounds for `base`, `aeson`, and `tasty` to permit a build plan that is compatible with GHC 9.10.