### PR TITLE
Allow building with GHC 9.12

### DIFF
--- a/named-text.cabal
+++ b/named-text.cabal
@@ -58,7 +58,7 @@ library
     import:           bldspec
     hs-source-dirs:   .
     default-language: Haskell2010
-    build-depends:    base >= 4.13 && < 4.21
+    build-depends:    base >= 4.13 && < 4.22
                     , deepseq
                     , hashable
                     , prettyprinter >= 1.7.0 && < 1.8


### PR DESCRIPTION
This bumps the upper version bounds for `base` to permit a build plan that is compatible with GHC 9.12.